### PR TITLE
Use aws-sdk-s3 instead aws-sdk

### DIFF
--- a/lib/s3_assets_uploader/config.rb
+++ b/lib/s3_assets_uploader/config.rb
@@ -1,4 +1,4 @@
-require 'aws-sdk'
+require 'aws-sdk-s3'
 
 module S3AssetsUploader
   class Config < Struct.new(:s3_client, :bucket, :assets_path, :assets_prefix, :additional_paths, :cache_control)

--- a/s3_assets_uploader.gemspec
+++ b/s3_assets_uploader.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "aws-sdk", ">= 2.0"
+  spec.add_dependency "aws-sdk-s3", ">= 1.0"
   spec.add_dependency "mime-types"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
The aws-sdk gem version 3 is now released and it depends on the separated feature specific gems.

So this commit changes the dependent gem under the following document:
https://github.com/aws/aws-sdk-ruby/blob/master/V3_UPGRADING_GUIDE.md