### PR TITLE
configurable_guess_content_type

### DIFF
--- a/lib/s3_assets_uploader/config.rb
+++ b/lib/s3_assets_uploader/config.rb
@@ -1,7 +1,7 @@
 require 'aws-sdk-s3'
 
 module S3AssetsUploader
-  class Config < Struct.new(:s3_client, :bucket, :assets_path, :assets_prefix, :additional_paths, :cache_control)
+  class Config < Struct.new(:s3_client, :bucket, :assets_path, :assets_prefix, :additional_paths, :cache_control, :content_type)
     class ValidationError < StandardError
     end
 
@@ -12,6 +12,7 @@ module S3AssetsUploader
       self.assets_path = DEFAULT_ASSETS_PATH
       self.cache_control = DEFAULT_CACHE_CONTROL
       self.additional_paths = []
+      self.content_type = nil
     end
 
     def assets_path
@@ -31,6 +32,16 @@ module S3AssetsUploader
       end
       self.s3_client ||= create_default_client
       true
+    end
+
+    def content_type(&block)
+      self[:content_type] = block
+    end
+
+    def guess_content_type(path)
+      return unless self[:content_type]
+
+      self[:content_type].call(path)
     end
 
     private

--- a/lib/s3_assets_uploader/uploader.rb
+++ b/lib/s3_assets_uploader/uploader.rb
@@ -45,6 +45,9 @@ module S3AssetsUploader
     end
 
     def guess_content_type(path)
+      content_type = @config.guess_content_type(path)
+      return content_type if content_type
+
       mime_type = MIME::Types.type_for(path.basename.to_s).first
       if mime_type
         mime_type.content_type

--- a/spec/s3_assets_uploader/config_spec.rb
+++ b/spec/s3_assets_uploader/config_spec.rb
@@ -33,5 +33,21 @@ RSpec.describe S3AssetsUploader::Config do
         end
       end
     end
+
+    context 'with content_type block' do
+      before do
+        config.bucket = 'some-bucket'
+        config.content_type do |path|
+          next 'application/rss+xml' if path =~ /rss\.xml$/
+          next 'application/atom+xml' if path =~ /atom\.xml$/
+        end
+      end
+
+      it 'return content_type' do
+        expect(config.guess_content_type('public/rss.xml')).to eq 'application/rss+xml'
+        expect(config.guess_content_type('public/atom.xml')).to eq 'application/atom+xml'
+        expect(config.guess_content_type('hello.jpg')).to eq nil
+      end
+    end
   end
 end

--- a/spec/s3_assets_uploader/uploader_spec.rb
+++ b/spec/s3_assets_uploader/uploader_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe S3AssetsUploader::Uploader do
   let(:assets_prefix) { nil }
   let(:cache_control) { 'public' }
   let(:additional_paths) { [] }
+  let(:content_type) { nil }
   let(:bucket) { 'bucket-name' }
   let(:s3) { double('Aws::S3::Client') }
   let(:uploader) do
@@ -16,6 +17,7 @@ RSpec.describe S3AssetsUploader::Uploader do
       config.assets_prefix = assets_prefix
       config.cache_control = cache_control
       config.additional_paths = additional_paths
+      config.content_type = content_type
     end
   end
 
@@ -64,6 +66,19 @@ RSpec.describe S3AssetsUploader::Uploader do
         expect(s3).to receive(:put_object).with(hash_including(bucket: bucket, key: 'assets/application-d3e5db26ec3f7b24a11084278a3e42cabf25ffa312bf25c6914d3874cc84396b.js', cache_control: 'max-age=86400, public'))
         uploader.upload
       end
+    end
+  end
+
+  describe 'guess_content_type' do
+    let(:content_type) do
+      proc do |path|
+        next 'application/rss+xml' if path =~ /rss\.xml$/
+        next 'application/atom+xml' if path =~ /atom\.xml$/
+      end
+    end
+
+    it 'return custom content_type when matched' do
+      expect(uploader.send(:guess_content_type, 'public/rss.xml')).to eq 'application/rss+xml'
     end
   end
 end


### PR DESCRIPTION
enable to configure `guess_content_type` .
especially, it is useful for many type of xml files.

```
S3AssetsUploader::RakeTask.new(:upload) do |config|
  config.content_type do |path|
     next 'application/rss+xml' if path.match?(/rss\.xml$/)
  end
end
```